### PR TITLE
separate specs with space, not -

### DIFF
--- a/conda_tools/environment.py
+++ b/conda_tools/environment.py
@@ -80,7 +80,7 @@ class Environment(object):
         specs = []
         for i in json_objs:
             p, v, b = i['name'], i['version'], i['build']
-            specs.append('{}-{}-{}'.format(p, v, b))
+            specs.append('{} {} {}'.format(p, v, b))
         return tuple(specs)
 
     @property


### PR DESCRIPTION
package names can have spaces in them.  If you use - in creating the specs here, it is much harder to parse the result, since you have to split on - and then count stuff, rather than just splitting.

This change keeps a functional working spec that should be easier to parse.