### PR TITLE
add pathlib2 import/dep for py2 compat

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,11 +6,15 @@ source:
   git_url: ..
   git_rev: master
 
+build:
+  number: 1
+
 requirements:
   build:
     - python
   run:
     - python
+    - pathlib2   [py<3]
 
 about:
   home: https://github.com/groutr/conda-tools

--- a/conda_tools/cache.py
+++ b/conda_tools/cache.py
@@ -4,8 +4,11 @@ import bz2
 from tarfile import (open as topen, TarFile, is_tarfile)
 from os.path import (join, exists, isdir, realpath, normpath, split)
 from tempfile import mkstemp
-from pathlib import PurePath
 from hashlib import md5
+try:
+    from pathlib import PurePath
+except:
+    from pathlib2 import PurePath
 
 from .common import lazyproperty, lru_cache
 from .config import config


### PR DESCRIPTION
pathlib is py3k, but has been backported.  This allows the import, at least.