### PR TITLE
Pool JSON dictionaries PackageInfo objects to save memory.

### DIFF
--- a/conda_tools/cache.py
+++ b/conda_tools/cache.py
@@ -27,6 +27,30 @@ class BadLinkError(Exception):
 class BadPathError(Exception):
     pass
 
+
+class PackagePool(object):
+    """
+    Common pool for sharing PackageInfo objects.
+    """
+    def __init__(self):
+        self._pool = {}
+
+    def register(self, pkg_obj):
+        obj_hash = hash(pkg_obj)
+        try:
+            return self._pool[obj_hash]
+        except KeyError:
+            self._pool[obj_hash] = pkg_obj
+            return pkg_obj
+
+    def update(self, pkg_obj):
+        self._pool[hash(pkg_obj)] = pkg_obj
+
+    def clear(self):
+        self._pool.clear()
+
+Pool = PackagePool()
+
 class PackageInfo(object):
     def __init__(self, path):
         """

--- a/conda_tools/environment.py
+++ b/conda_tools/environment.py
@@ -27,18 +27,19 @@ class DictionaryPool(object):
     def register(self, d):
         d_id = id(d)
         _pool = self._pool
-        if d_id not in _pool:
-            # check to see if obj is in cache O(n)
-            for _id, _d in _pool.items():
+
+        try:
+            return _pool[d_id]
+        except KeyError:
+            # maybe a dict with same content in pool.
+            for _d in _pool.values():
                 if d == _d:
-                    # destroy reference to obj
-                    d = None
                     return _d
             
             if self.intern_keys:
                 d = self._intern_keys(d)
             self._pool[d_id] = d
-        return d
+            return d
     
     def _intern_keys(self, d):
         """

--- a/conda_tools/environment.py
+++ b/conda_tools/environment.py
@@ -5,11 +5,60 @@ from os.path import join, isdir, basename, dirname
 from functools import reduce
 
 from .common import lazyproperty, lru_cache
-from .cache import PackageInfo
+from .cache import PackageInfo, Pool as PkgPool
 from .history import History
 
 class InvalidEnvironment(Exception):
     pass
+
+
+class DictionaryPool(object):
+    """
+    Store only unique dictionaries.
+
+    Optional string interning can be enabled to as an extra memory optimization.
+    """
+    from sys import intern
+
+    def __init__(self, intern_keys=False):
+        self._pool = {}
+        self.intern_keys = intern_keys
+
+    def register(self, d):
+        d_id = id(d)
+        _pool = self._pool
+        if d_id not in _pool:
+            # check to see if obj is in cache O(n)
+            for _id, _d in _pool.items():
+                if d == _d:
+                    # destroy reference to obj
+                    d = None
+                    return _d
+            
+            if self.intern_keys:
+                d = self._intern_keys(d)
+            self._pool[d_id] = d
+        return d
+    
+    def _intern_keys(self, d):
+        """
+        Intern the string keys of d
+        """
+        intern = DictionaryPool.intern
+        for k, v in d.items():
+            try:
+                d[intern(k)] = v
+            except TypeError:
+                d[k] = v
+
+            if isinstance(v, dict):
+                d[k] = self._intern_keys(v)
+        return d
+
+    def clear(self):
+        self._cache.clear()
+            
+Pool = DictionaryPool(intern_keys=True)
 
 class Environment(object):
     def __init__(self, path):
@@ -57,6 +106,10 @@ class Environment(object):
             for p in pi:
                 package_info[p.name] = p
         return package_info
+
+    def get_field(self, field):
+        self._read_package_json()
+        return {i['name']: i.get(field) for i in self._packages.values()}
 
     @lazyproperty
     def package_channels(self):
@@ -116,7 +169,7 @@ class Environment(object):
                 ltype, lsource = link['type'], link['source']
             else:
                 ltype, lsource = 'hard-link', self.path
-            result[ltype].append(PackageInfo(lsource))
+            result[ltype].append(PkgPool.register(PackageInfo(lsource)))
 
         if link_type == 'all':
             return {k: tuple(v) for k, v in result.items()}
@@ -155,7 +208,7 @@ def _load_all_json(path):
 
 def _load_json(path):
     with open(path, 'r') as fin:
-        x = json.load(fin)
+        x = Pool.register(json.load(fin))
     return x
 
 def is_conda_env(path):


### PR DESCRIPTION
Add the ability to pool frequently used objects to save memory.  We don't want to cache the objects as they are constructed because newly created objects are the recommended way to re-read from disk.  However, when loading json files from environments or creating PackageInfo objects for environments, we don't need multiple instances to represent the same information.  For example, we can reuse the readline PackageInfo object across all the environments that have that exact version of readline installed, and we also only store one copy of the json file from conda-meta.