### PR TITLE
Repository interface

### DIFF
--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -10,7 +10,7 @@ from .compat import ditems, urlopen
 
 PACKAGE_FIELDS = (
     'build', 'build_number', 'date', 'date', 'depends', 'requires',
-    'license', 'license_family', 'md5', 'size', 'version', 'name'
+    'license', 'license_family', 'md5', 'size', 'version', 'name', 'sha256'
 )
 
 class RepoPackage(object):
@@ -21,16 +21,12 @@ class RepoPackage(object):
         for field in PACKAGE_FIELDS:
             setattr(self, field, info.get(field))
 
-        if hasattr(self, 'sha256'):
-            self.hashfield = self.sha256
-        else:
-            self.hashfield = self.md5
-
     def __hash__(self):
-        return hash(self.hashfield)
+        return hash(self.sha256)
 
-    def __eq__(self):
-        return self.hashfield
+    def __eq__(self, other):
+        if self.__class__ == other.__class__:
+            return self.sha256 == other.sha256
 
     def __repr__(self):
         return 'RepoPackage({})'.format(self.filename)
@@ -61,7 +57,7 @@ class Repository(object):
         base_url = self.url
         for p in pkgs:
             if p in self.packages:
-                yield base_url + p.filename, p.md5
+                yield join(base_url, p.filename), p.sha256
 
 def get_repo(url, platform=None):
     if platform is not None:

--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -1,3 +1,12 @@
+from __future__ import print_function
+
+import bz2
+from json import loads
+from os.path import join
+
+
+from .compat import ditems, urlopen
+
 
 PACKAGE_FIELDS = (
     'build', 'build_number', 'date', 'date', 'depends', 'requires',
@@ -23,7 +32,7 @@ class RepoPackage(object):
 
 
 def repo_packages(d):
-    return set(RepoPackage(*info) for info in d.items())
+    return set(RepoPackage(*info) for info in ditems(d))
 
 class Repository(object):
     def __init__(self, url, data):
@@ -46,3 +55,16 @@ class Repository(object):
         for p in pkgs:
             if p in self.packages:
                 yield base_url + p.filename, p.md5
+
+def get_repo(url, platform=None):
+    if platform is not None:
+        ch_url = join(url, platform)
+    else:
+        ch_url = url
+
+    x = urlopen(join(ch_url, 'repodata.json.bz2'))
+    x = bz2.decompress(x.read())
+    
+    repo_json = loads(x.decode('utf8'))
+    return Repository(ch_url, repo_json)
+

--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -21,8 +21,16 @@ class RepoPackage(object):
         for field in PACKAGE_FIELDS:
             setattr(self, field, info.get(field))
 
+        if hasattr(self, 'sha256'):
+            self.hashfield = self.sha256
+        else:
+            self.hashfield = self.md5
+
     def __hash__(self):
-        return hash(self.md5)
+        return hash(self.hashfield)
+
+    def __eq__(self):
+        return self.hashfield
 
     def __repr__(self):
         return 'RepoPackage({})'.format(self.filename)
@@ -37,8 +45,7 @@ def repo_packages(d):
 class Repository(object):
     def __init__(self, url, data):
         self.url = url
-        self.arch = data['info']['arch']
-        self.platform = data['info']['platform']
+        self.subdir = data['info']['subdir']
         self.packages = repo_packages(data['packages'])
 
     def __repr__(self):

--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -1,0 +1,33 @@
+class RepoPackage(object):
+    def __init__(self, filename, info):
+        self.filename = filename
+        self.__dict__.update(info)
+
+    def __hash__(self):
+        return hash(self.md5)
+
+    def __repr__(self):
+        return 'RepoPackage({})'.format(self.filename)
+
+    def __str__(self):
+        return '{} {} {}'.format(self.name, self.version, self.build)
+
+
+def repo_packages(d):
+    return set(RepoPackage(*info) for info in d.items())
+
+class Repository(object):
+    def __init__(self, url, data):
+        self.url = url
+        self.arch = data['info']['arch']
+        self.platform = data['info']['platform']
+        self.packages = repo_packages(data['packages'])
+
+    def __repr__(self):
+        return 'Repository({})'.format(self.url)
+
+    def __eq__(self, other):
+        try:
+            return (self.url == other.url) and (self.packages == other.packages)
+        except:
+            return False

--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -40,3 +40,9 @@ class Repository(object):
             return (self.url == other.url) and (self.packages == other.packages)
         except:
             return False
+
+    def fetch_urls(self, pkgs):
+        base_url = self.url
+        for p in pkgs:
+            if p in self.packages:
+                yield base_url + p.filename, p.md5

--- a/conda_tools/repository.py
+++ b/conda_tools/repository.py
@@ -1,7 +1,16 @@
+
+PACKAGE_FIELDS = (
+    'build', 'build_number', 'date', 'date', 'depends', 'requires',
+    'license', 'license_family', 'md5', 'size', 'version', 'name'
+)
+
 class RepoPackage(object):
+    __slots__ = ('filename',) + PACKAGE_FIELDS    
     def __init__(self, filename, info):
         self.filename = filename
-        self.__dict__.update(info)
+
+        for field in PACKAGE_FIELDS:
+            setattr(self, field, info.get(field))
 
     def __hash__(self):
         return hash(self.md5)


### PR DESCRIPTION
Give repodata.json the conda-tools treatment.

After I get a compatibility module committed for Python 2/3 compatibility, fetching repodata from a channel can be implemented (using the standard library, of course).

What methods/functions would be useful for handling repodata?

cc: @msarahan 